### PR TITLE
Upgrade react-addons-shallow-compare version from 15.4.2 to 15.6.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "moment": "2.15.1",
     "react": "15.4.2",
-    "react-addons-shallow-compare": "15.4.2",
+    "react-addons-shallow-compare": "15.6.2",
     "react-dates": "12.4.0",
     "react-dom": "15.4.2"
   },


### PR DESCRIPTION
This PR is to upgrade the version number of react-addons-shallow-compare to 15.6.2. My organization explicitly blacklisted all versions of react-addons-shallow-compare except 15.6.2. This PR should be minimal impact to the project, but would benefit us a lot. I would really appreciate it if you could merge this change in, if it doesn't do any harms. Thanks!